### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ramartinez7/semantic-search/security/code-scanning/3](https://github.com/ramartinez7/semantic-search/security/code-scanning/3)

To fix the problem, you must set the minimal necessary permissions for the workflow by adding a `permissions` block. This can be done either at the root of the workflow (applies to all jobs) or under each job definition. Given both jobs (`build` and `build-windows`) perform only read operations, the `contents: read` permission should be set. The best practice is to set this at the root level unless individual jobs require different permissions. Edit `.github/workflows/ci.yml` to add the `permissions` block at the top level, directly after the `name:` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
